### PR TITLE
Need possibility to send byte-arrays to rabbitMq

### DIFF
--- a/src/groovy/org/grails/rabbitmq/RabbitDynamicMethods.groovy
+++ b/src/groovy/org/grails/rabbitmq/RabbitDynamicMethods.groovy
@@ -3,6 +3,7 @@ package org.grails.rabbitmq
 import org.springframework.amqp.core.Address
 import org.springframework.amqp.core.Message
 import org.springframework.amqp.core.MessagePostProcessor
+import org.springframework.amqp.core.MessageProperties
 
 /**
  * Class for applying the dynamic rabbitSend() and rabbitRpcSend() methods to
@@ -12,6 +13,7 @@ class RabbitDynamicMethods {
     
     static void applyAllMethods(target, ctx) {
         applyRabbitSend(target, ctx)
+        applyRabbitSendByteArray(target, ctx)
 //        applyRabbitRpcSend(target, ctx)
     }
     
@@ -23,6 +25,15 @@ class RabbitDynamicMethods {
             // checks for String, we do the conversion manually.
             args = processArgs(args)
             ctx.rabbitTemplate.convertAndSend(*args)
+        }
+    }
+
+    static void applyRabbitSendByteArray(target, ctx) {
+        target.metaClass.rabbitSendByteArray = { Object[] args ->
+            String routingKey = args[0]
+            MessageProperties messageProperties = new MessageProperties()
+            Message message = new Message(args[1], messageProperties)
+            ctx.rabbitTemplate.send(routingKey, message)
         }
     }
 


### PR DESCRIPTION
Since convertAndSend takes an Object I could not use it to send a byte[]. We use RabbitMQ to send protobuf-object serialized into byte-arrays and this simple method worked for us to be able to use it for that.
