### PR TITLE
Documentation Error - connectionFactory should be connectionfactory

### DIFF
--- a/src/docs/guide/configuration/configuringExchanges.gdoc
+++ b/src/docs/guide/configuration/configuringExchanges.gdoc
@@ -6,7 +6,7 @@ Let's start with an example of how to set up a simple exchange (with no queues):
 
 {code}
 rabbitmq {
-    connectionFactory {
+    connectionfactory {
         ...
     }
     queues = {
@@ -48,7 +48,7 @@ An exchange on its own isn't particularly useful, but we can easily bind queues 
 
 {code}
 rabbitmq {
-    connectionFactory {
+    connectionfactory {
         ...
     }
     queues = {


### PR DESCRIPTION
In the documentation describing exchanges, the DSL reads:

```
rabbitmq {
    connectionFactory {
        ...
    }
    queues = {
        exchange name: 'my.topic', type: topic
    }
}
```

Note the capital F in factory. 

When running this, the application shows an error:

```
[localhost-startStop-1] ERROR RabbitmqGrailsPlugin  - RabbitMQ connection factory settings (rabbitmq.connectionfactory.username, rabbitmq.connectionfactory.password and rabbitmq.connectionfactory.hostname) must be defined in Config.groovy

```

The attached patch fixes this error in the documentation. 
